### PR TITLE
Batch mode downloads, reverse order downloads, smarter downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ Linux/Mac users: The script has a shebang, so you may run it as `./kissmanga-dow
 Here is the output of the `python kissmanga-download.py -h`:
 
 ```
-usage: kissmanga-downloader.py [-h] [-o OUTPUT] -u URL (-i INI | -r) [-e END]
-                               [--pdf] [--cbz] [--delete_jpg] [--pdf_series]
-                               [--chapter_page] [--delay DELAY] [--ow]
+usage: kissmanga-downloader.py [-h] [-o OUTPUT]
+                               (-u URL | --batch_file BATCH_FILE)
+                               [-i INI | -r] [-e END] [--pdf] [--cbz]
+                               [--delete_jpg] [--pdf_series] [--chapter_page]
+                               [--delay DELAY] [--ow]
 
 Batch-download chapters and series from Kissmanga
 
@@ -63,6 +65,8 @@ optional arguments:
                         kissmanga URL, so for
                         'https://kissmanga.in/kissmanga/dungeon-meshi' use
                         'dungeon-meshi')
+  --batch_file BATCH_FILE
+                        Process a batch file of URL's
   -i INI, --ini INI     Initial chapter number to download, in [1..n]
   -r, --reverse         Download in reverse order, stop when existing
                         downloads are found.
@@ -71,7 +75,7 @@ optional arguments:
   --cbz                 Generate a CBZ file for each chapter
   --delete_jpg          Delete jpg files after cbz creation
   --pdf_series          Generate a huge PDF file with all chapters
-  --chapter_page        Render a chapter page and put it in front of the PDDF
+  --chapter_page        Render a chapter page and put it in front of the PDF
                         of each chapter
   --delay DELAY         Add a delay (in seconds) between page downloads to
                         avoid overloading the server
@@ -90,6 +94,14 @@ If you have already downloaded a manga, and want to grab the lastest updates for
 python kissmanga-downloader.py -u dungeon-meshi -o /output/folder/path -r --cbz --delete_jpg
 ```
 
+A batch file is simply a file containing a list of URL's to download one at a time.
+If a line starts with a '#', it will be ignored, and blank lines will be ignored.
+
+For example, to download the first two chapters of every manga listed in /tmp/batch.txt, create cbz files of them, and clean up all jpgs when done:
+
+'''
+python kissmanga-downloader.py --batch_file /tmp/batch.txt --cbz --delete_jpg -o /output/folder/path -e 2
+'''
 
 ## Features
 
@@ -98,4 +110,5 @@ python kissmanga-downloader.py -u dungeon-meshi -o /output/folder/path -r --cbz 
 *  Checks for a cbz/pdf file, and skips download of entire chapter if found.
 *  Delete jpg files when finished creating a cbz
 *  Creates a ComicInfo.xml file when creating a cbz (used by certain CBZ readers to automatically provide metadata to the reader, such as author/genre/name/etc)
-
+*  Process a batch file of urls to download
+*  Download chapters in reverse order for use in a nightly download to grab the latest chapters

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Linux/Mac users: The script has a shebang, so you may run it as `./kissmanga-dow
 Here is the output of the `python kissmanga-download.py -h`:
 
 ```
-usage: kissmanga-downloader.py [-h] [-o OUTPUT] -u URL -i INI -e END [--pdf]
-                               [--cbz] [--delete_jpg] [--pdf_series]
+usage: kissmanga-downloader.py [-h] [-o OUTPUT] -u URL (-i INI | -r) [-e END]
+                               [--pdf] [--cbz] [--delete_jpg] [--pdf_series]
                                [--chapter_page] [--delay DELAY] [--ow]
 
 Batch-download chapters and series from Kissmanga
@@ -61,9 +61,11 @@ optional arguments:
                         script is run
   -u URL, --url URL     Name of the series, no need to include the base
                         kissmanga URL, so for
-                        'https://kissmanga.com/Manga/Dragon-Ball' use'Dragon-
-                        Ball)
+                        'https://kissmanga.in/kissmanga/dungeon-meshi' use
+                        'dungeon-meshi')
   -i INI, --ini INI     Initial chapter number to download, in [1..n]
+  -r, --reverse         Download in reverse order, stop when existing
+                        downloads are found.
   -e END, --end END     Final chapter number to download, included
   --pdf                 Generate a PDF file for each chapter
   --cbz                 Generate a CBZ file for each chapter
@@ -76,10 +78,16 @@ optional arguments:
   --ow                  Overwrite existing PDF files
 ```
 
-For instance, to get the first 100 chapters of Dragon Ball, generating only chapter PDFs and adding a title page to each chapter, with `/output/folder/path` as the output folder:
+For instance, to get the first 50 chapters of Dungeon Meshi, generating only chapter PDFs and adding a title page to each chapter, with `/output/folder/path` as the output folder:
 
 ```
-python kissmanga-downloader.py -u Dragon-Ball -o /output/folder/path -i 1 -e 100 --pdf --chapter_page --ow
+python kissmanga-downloader.py -u dungeon-meshi -o /output/folder/path -i 1 -e 50 --pdf --chapter_page --ow
+```
+
+If you have already downloaded a manga, and want to grab the lastest updates for it in cbz format, and clean up the img files when done:
+
+```
+python kissmanga-downloader.py -u dungeon-meshi -o /output/folder/path -r --cbz --delete_jpg
 ```
 
 

--- a/kissmanga-downloader.py
+++ b/kissmanga-downloader.py
@@ -74,8 +74,8 @@ def gather_xml_info(driver, title_text):
     Dig through the first page and gather data for a Comicinfo.xml file
     """
     xml_root = ET.Element('ComicInfo',
-                          {'xmlns:xsi':'http://www.w3.org/2001/XMLSchema-instance',
-                           'xmlns:xsd':'http://www.w3.org/2001/XMLSchema'})
+                          {'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+                           'xmlns:xsd': 'http://www.w3.org/2001/XMLSchema'})
 
     xml_series = ET.SubElement(xml_root, 'Series')
     xml_series.text = title_text
@@ -133,7 +133,7 @@ def get_title_and_chapter_links(driver, url_to_series, reverse=False):
         sys.exit("Couldn't get title!")
 
     if '\n' in title_text:
-        title_text = title_text[(title_text.index('\n')+1):]
+        title_text = title_text[(title_text.index('\n') + 1):]
 
     xml_root = gather_xml_info(driver, title_text)
 
@@ -163,7 +163,7 @@ def download_pages_of_one_chapter(driver, url_to_chapter, xmlroot,
     os.chdir(series_folder)
 
     try:
-        drop_down_list = WebDriverWait(driver, 15).until(EC.presence_of_element_located((By.CLASS_NAME,"reading-style-select")))
+        WebDriverWait(driver, 15).until(EC.presence_of_element_located((By.CLASS_NAME, "reading-style-select")))
     except TimeoutException:
         print("Exception Occured:    TimeoutException")
         print("Couldn't load chapter: " + url_to_chapter)
@@ -175,7 +175,7 @@ def download_pages_of_one_chapter(driver, url_to_chapter, xmlroot,
         chapter_name = chapter_name[:-1]
 
     # Unify format by parsing number out of chapter_name
-    chapter_number = (re.findall('\d+.?\d*', chapter_name)[0]).replace('-', '.')
+    chapter_number = (re.findall(r'\d+.?\d*', chapter_name)[0]).replace('-', '.')
     chapter_folder_name = "Chapter-" + chapter_number
     if chapter_folder_name.endswith('.'):
         chapter_folder_name = chapter_folder_name[:-1]
@@ -222,7 +222,7 @@ def download_pages_of_one_chapter(driver, url_to_chapter, xmlroot,
         else:
             print(" " + page_num_pad, end="")
             try:
-                req = urllib.request.Request(img_url, headers={'User-Agent' : "Magic Browser"})
+                req = urllib.request.Request(img_url, headers={'User-Agent': "Magic Browser"})
                 con = urllib.request.urlopen(req)
                 img_good = True
                 img_data = con.read()
@@ -289,7 +289,7 @@ def process(driver):
     parser.add_argument('-o', '--output', type=str,
                         help="Output folder path where the series folder will be created. Defaults to the current path from which this script is run")
     parser.add_argument('-u', '--url', required=True, type=str,
-                        help="Name of the series, no need to include the base kissmanga URL, so for 'https://kissmanga.com/Manga/Dragon-Ball' use'Dragon-Ball)")
+                        help="Name of the series, no need to include the base kissmanga URL, so for 'https://kissmanga.in/kissmanga/dungeon-meshi' use 'dungeon-meshi')")
 
     parser_group = parser.add_mutually_exclusive_group(required=True)
     parser_group.add_argument('-i', '--ini', type=int,
@@ -309,7 +309,7 @@ def process(driver):
     parser.add_argument('--pdf_series', required=False, action='store_true',
                         help="Generate a huge PDF file with all chapters")
     parser.add_argument('--chapter_page', required=False, action='store_true',
-                        help="Render a chapter page and put it in front of the PDDF of each chapter")
+                        help="Render a chapter page and put it in front of the PDF of each chapter")
     parser.add_argument('--delay', required=False, type=float,
                         help="Add a delay (in seconds) between page downloads to avoid overloading the server")
     parser.add_argument('--ow', required=False, action='store_true',

--- a/kissmanga-downloader.py
+++ b/kissmanga-downloader.py
@@ -131,7 +131,7 @@ def get_title_and_chapter_links(driver, url_to_series, reverse=False):
         title_text = title_tag.text.encode("ascii", errors="ignore").decode()
     except TimeoutException:
         print("Exception Occured:    TimeoutException")
-        sys.exit("Couldn't get title!")
+        return None, [], None
 
     if '\n' in title_text:
         title_text = title_text[(title_text.index('\n') + 1):]
@@ -337,6 +337,9 @@ def process_one_url(driver, url, output_folder, args):
         title, list_of_hrefs, xmlroot = get_title_and_chapter_links(driver, url, args.reverse)
         nrof_urls = len(list_of_hrefs)
         tries = tries - 1
+        # abort if we got a timeout error
+        if title is None or xmlroot is None:
+            tries = -1
         print(".", end="")
         sys.stdout.flush()
         time.sleep(2)

--- a/kissmanga-downloader.py
+++ b/kissmanga-downloader.py
@@ -66,7 +66,7 @@ def init_driver():
     else:
         driver = webdriver.Chrome(chrome_options=options)
 
-    driver.set_page_load_timeout(90)
+    driver.set_page_load_timeout(150)
     return driver
 
 

--- a/kissmanga-downloader.py
+++ b/kissmanga-downloader.py
@@ -159,7 +159,12 @@ def download_pages_of_one_chapter(driver, url_to_chapter, xmlroot,
     """
 
     # Going to first page
-    driver.get(url_to_chapter)
+    try:
+        driver.get(url_to_chapter)
+    except TimeoutException:
+        print("Couldn't load chapter: " + url_to_chapter)
+        return -1
+
     os.chdir(series_folder)
 
     try:
@@ -291,8 +296,8 @@ def process(driver):
     parser.add_argument('-u', '--url', required=True, type=str,
                         help="Name of the series, no need to include the base kissmanga URL, so for 'https://kissmanga.in/kissmanga/dungeon-meshi' use 'dungeon-meshi')")
 
-    parser_group = parser.add_mutually_exclusive_group(required=True)
-    parser_group.add_argument('-i', '--ini', type=int,
+    parser_group = parser.add_mutually_exclusive_group(required=False)
+    parser_group.add_argument('-i', '--ini', type=int, default=1,
                               help="Initial chapter number to download, in [1..n]")
     parser_group.add_argument('-r', '--reverse', action='store_true',
                               default=False,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ selenium
 reportlab
 PyPDF2
 pillow
+fake_useragent


### PR DESCRIPTION
This is the last of my fixups, it now does everything I want.  :)

Add reverse order download (newest first)
Add description parsing from the site into the ComicInfo.xml
Change how we detect if a chapter has already been downloaded so it doesn't load the page first, less hits on the site, way faster on re-check now.
Refactor the code so we can download in batch mode, accept a file of URL's, and download each one.  This is suitable for use in a cron job that downloads the newest chapters every night, and runs very quickly with very few hits on the site if most of the chapters already exist.
Make almost all of the options optional.  Only option required now is either -u for url or --batch-file for the list.
Various doc fixes in the readme.